### PR TITLE
Add pipeline for container build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository_owner }}/midl-status
+        images: ghcr.io/${{ github.repository_owner }}/cli
         tags: |
           type=ref,event=branch
           type=ref,event=pr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Run Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types: [created]
+
+jobs:
+  publish_containers:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Login to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/midl-status
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=match,pattern=v(.*),group=1
+
+    - name: Push to GHCR
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ data.db-journal
 messages.txt
 qr.png
 last_spent_portal_coinid
+
+# intellij
+.idea


### PR DESCRIPTION
github has GHCR support for opensource projects, we can leverage that to distribute containers